### PR TITLE
fix: require nodejs v22.12.0 or later

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
         runs-on: ubuntu-latest
         strategy:
             matrix:
-                node-version: [20.x, 22.x]
+                node-version: [22.x, 24.x]
         steps:
             - uses: actions/checkout@v5
             - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -13,7 +13,7 @@ jobs:
             - name: Use Node.js 20.x
               uses: actions/setup-node@v4
               with:
-                  node-version: 20.x
+                  node-version: 22.x
             - name: Install dependencies
               run: npm ci
             - name: Prettier

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,7 +17,7 @@ jobs:
             - name: Setup Node.js
               uses: actions/setup-node@v4
               with:
-                  node-version: 20.x
+                  node-version: 22.x
             - name: Install dependencies
               run: npm ci
             - name: Build

--- a/build.js
+++ b/build.js
@@ -13,7 +13,7 @@ await build({
     bundle: true,
     format: "esm",
     platform: "node",
-    target: "node20",
+    target: "node22",
     logLevel: "info",
     banner: {
         js: `

--- a/package-lock.json
+++ b/package-lock.json
@@ -33,7 +33,7 @@
         "@html-validate/release-scripts": "6.9.0",
         "@types/is-ci": "3.0.4",
         "@types/jest": "29.5.14",
-        "@types/node": "20.19.10",
+        "@types/node": "22.12.0",
         "conventional-changelog-conventionalcommits": "9.1.0",
         "esbuild": "0.25.9",
         "husky": "9.1.7",
@@ -42,7 +42,8 @@
         "rimraf": "6.0.1"
       },
       "engines": {
-        "node": ">= 20.18"
+        "node": ">= 22.12.0",
+        "npm": ">= 10.0.0"
       },
       "peerDependencies": {
         "ts-node": "^10"
@@ -2843,12 +2844,12 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.10",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.10.tgz",
-      "integrity": "sha512-iAFpG6DokED3roLSP0K+ybeDdIX6Bc0Vd3mLW5uDqThPWtNos3E+EqOM11mPQHKzfWHqEBuLjIlsBQQ8CsISmQ==",
+      "version": "22.12.0",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.12.0.tgz",
+      "integrity": "sha512-Fll2FZ1riMjNmlmJOdAyY5pUbkftXslB5DgEzlIuNaiWhXd00FhWxVC/r4yV/4wBb9JfImTu+jiSvXTkJ7F/gA==",
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~6.20.0"
       }
     },
     "node_modules/@types/stack-utils": {
@@ -10230,7 +10231,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
+      "version": "6.20.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.20.0.tgz",
+      "integrity": "sha512-Ny6QZ2Nju20vw1SRHe3d9jVu6gJ+4e3+MMpqu7pqE5HT6WsTSlce++GQmK5UXS8mzV8DSYHrQH+Xrf2jVcuKNg==",
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {

--- a/package.json
+++ b/package.json
@@ -96,7 +96,7 @@
     "@html-validate/release-scripts": "6.9.0",
     "@types/is-ci": "3.0.4",
     "@types/jest": "29.5.14",
-    "@types/node": "20.19.10",
+    "@types/node": "22.12.0",
     "conventional-changelog-conventionalcommits": "9.1.0",
     "esbuild": "0.25.9",
     "husky": "9.1.7",
@@ -108,7 +108,8 @@
     "ts-node": "^10"
   },
   "engines": {
-    "node": ">= 20.18"
+    "node": ">= 22.12.0",
+    "npm": ">= 10.0.0"
   },
   "externalDependencies": [
     "lint-staged",


### PR DESCRIPTION
BREAKING CHANGE: NodeJS v22.12.0 or later is now required.


Do not merge before: (bundle both changes in same release)
https://github.com/Forsakringskassan/commitlint-config/pull/25