### PR TITLE
fix: husky validation should not crash during check (refs SB-4982)

### DIFF
--- a/src/install.ts
+++ b/src/install.ts
@@ -73,7 +73,7 @@ async function setupGitHooks(): Promise<void> {
     if (
         invalidInstalledPackages(packageJson) ||
         existingSimpleGitConfig(packageJson) ||
-        (await existingHuskyConfig(originCwd, fsp))
+        (await existingHuskyConfig(originCwd, fs))
     ) {
         process.exit(1);
     }

--- a/src/verifyPackage.spec.ts
+++ b/src/verifyPackage.spec.ts
@@ -1,6 +1,6 @@
 import { createFsFromVolume, vol } from "memfs";
 
-type NodeFsPromises = typeof import("node:fs/promises");
+type NodeFs = typeof import("node:fs");
 
 import {
     invalidInstalledPackages,
@@ -103,10 +103,10 @@ describe("existingSimpleGitConfig", () => {
 });
 
 describe("existingHuskyConfig", () => {
-    let fs: NodeFsPromises;
+    let fs: NodeFs;
     beforeEach(() => {
         vol.reset();
-        fs = createFsFromVolume(vol).promises as unknown as NodeFsPromises;
+        fs = createFsFromVolume(vol) as unknown as NodeFs;
     });
 
     it("should return true if husky folder exists", async () => {

--- a/src/verifyPackage.ts
+++ b/src/verifyPackage.ts
@@ -1,4 +1,3 @@
-import path from "node:path";
 import { glob } from "glob";
 
 export interface packageJsonType {
@@ -55,12 +54,10 @@ export function existingSimpleGitConfig(packageJson: packageJsonType): boolean {
 
 export async function existingHuskyConfig(
     cwd: string,
-    fileSystem: typeof import("node:fs/promises"),
+    fileSystem: typeof import("node:fs"),
 ): Promise<boolean> {
     try {
-        const huskyPath = path.join(cwd, ".husky");
-        await fileSystem.stat(huskyPath);
-        const huskyFiles = await glob(`.husky/**/*`, {
+        const huskyFiles = await glob(".husky/**/*", {
             fs: fileSystem,
             ignore: ".husky/_/**",
             cwd,


### PR DESCRIPTION
Some sort of mismatch when passing in async version of `fs` into glob function. 

Results in following error message:
```
...Detected unsettled top-level await....
```