### PR TITLE
docs: add section regarding manually setup hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,12 +46,33 @@ or manually edit `package.json`:
 }
 ```
 
-## Git hooks
+## Adding hooks
 
-This package uses a postinstall script to automatically add Git hooks to your application.
+This package also provides the following git hooks:
 
-- Prettier and Esbuild will run before commit is created (if packages exist in your application
+- Prettier and Esbuild will run before a commit is created (if the packages exist in your application).
 - The commit message will be validated.
+
+To validate commit messages as commits are created, you also need to set up the Git hooks.
+
+### Running setup manually (Recommended)
+
+If you install with `--ignore-scripts`, the postinstall script will not run automatically.
+You can trigger the setup manually by calling the `commitlint-config` command, for example from your own `prepare` script:
+
+```json
+{
+    "scripts": {
+        "prepare": "commitlint-config"
+    }
+}
+```
+
+### Postinstall script (Deprecated, will be removed in future releases)
+
+Hooks will automatically be installed if you omit `--no-script` when installing an application with this package. However, this is not a recommended approach and this alternative will be removed.
+
+## Before installing this plugin
 
 If you already have `husky`, `simple-git-hooks` or `lint-staged` in your `package.json` you need uninstall them first:
 


### PR DESCRIPTION
Marked that `postinstall` script will be removed in the future.