### PR TITLE
test: integration test

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,7 +51,9 @@
     "prettier:check": "prettier . --check",
     "prettier:write": "prettier . --write",
     "pretest": "run-s eslint prettier:check",
-    "test": "vitest run"
+    "test": "vitest run && vitest run --mode integration",
+    "test:unit": "vitest run",
+    "test:integration": "vitest --mode integration"
   },
   "commitlint": {
     "extends": [

--- a/src/__snapshots__/install.integration.spec.ts.snap
+++ b/src/__snapshots__/install.integration.spec.ts.snap
@@ -1,0 +1,39 @@
+// Vitest Snapshot v1, https://vitest.dev/guide/snapshot.html
+
+exports[`install (integration) > should install git hooks after manually running commitlint-config command > commit-msg 1`] = `
+"#!/bin/sh
+
+if [ "$SKIP_SIMPLE_GIT_HOOKS" = "1" ]; then
+    echo "[INFO] SKIP_SIMPLE_GIT_HOOKS is set to 1, skipping hook."
+    exit 0
+fi
+
+if [ -f "$SIMPLE_GIT_HOOKS_RC" ]; then
+    . "$SIMPLE_GIT_HOOKS_RC"
+fi
+
+npm exec commitlint -- --edit "$1""
+`;
+
+exports[`install (integration) > should install git hooks after manually running commitlint-config command > pre-commit 1`] = `
+"#!/bin/sh
+
+if [ "$SKIP_SIMPLE_GIT_HOOKS" = "1" ]; then
+    echo "[INFO] SKIP_SIMPLE_GIT_HOOKS is set to 1, skipping hook."
+    exit 0
+fi
+
+if [ -f "$SIMPLE_GIT_HOOKS_RC" ]; then
+    . "$SIMPLE_GIT_HOOKS_RC"
+fi
+
+npm exec lint-staged -- --config "<tempDir>/node_modules/@forsakringskassan/commitlint-config/lint-staged.js" "$@""
+`;
+
+exports[`install (integration) > should install git hooks after manually running commitlint-config command > stdout 1`] = `
+"[INFO] Successfully set the pre-commit with command: npm exec lint-staged -- --config "<tempDir>/node_modules/@forsakringskassan/commitlint-config/lint-staged.js" "$@"
+[INFO] Successfully set the commit-msg with command: npm exec commitlint -- --edit "$1"
+[INFO] Successfully set all git hooks
+git config commit.template node_modules/@forsakringskassan/commitlint-config/gitmessage
+"
+`;

--- a/src/install.integration.spec.ts
+++ b/src/install.integration.spec.ts
@@ -1,0 +1,84 @@
+import { spawnSync } from "node:child_process";
+import { randomBytes } from "node:crypto";
+import fs, { realpathSync } from "node:fs";
+import { mkdir, rm } from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import packageJson from "../package.json" assert { type: "json" };
+
+const rootDir = path.join(import.meta.dirname, "..");
+const tarballName = `forsakringskassan-commitlint-config-${packageJson.version}.tgz`;
+const tarball = path.join(rootDir, tarballName);
+
+vi.setConfig({ testTimeout: 30_000 });
+
+function hookFile(dir: string, file: string): string {
+    return path.join(dir, ".git", "hooks", file);
+}
+
+describe("install (integration)", () => {
+    let tempDir: string;
+    const env: NodeJS.ProcessEnv = process.env;
+
+    function run(command: string): { stdout: string; stderr: string } {
+        /* eslint-disable-next-line sonarjs/os-command -- Static commands  */
+        const result = spawnSync(command, {
+            cwd: tempDir,
+            env,
+            encoding: "utf8",
+            shell: true,
+        });
+        return { stdout: result.stdout, stderr: result.stderr };
+    }
+
+    beforeEach(async () => {
+        const tempDirName = randomBytes(16).toString("hex");
+        tempDir = path.join(realpathSync(os.tmpdir()), tempDirName);
+        await mkdir(tempDir);
+
+        env["CI"] = "false";
+        env["npm_config_ignore_scripts"] = undefined; // Could be removed once postinstall script is removed
+
+        run("git init");
+        run("npm init -y");
+    });
+
+    afterEach(async () => {
+        await rm(tempDir, { recursive: true, force: true });
+    });
+
+    it("should install git hooks after manually running commitlint-config command", () => {
+        expect.assertions(4);
+
+        run(`npm install "${tarball}" --ignore-scripts`);
+        const { stdout } = run("npm exec commitlint-config");
+        expect(stdout.replaceAll(tempDir, "<tempDir>")).toMatchSnapshot(
+            "stdout",
+        );
+
+        const hooksDir = path.join(tempDir, ".git", "hooks");
+        const hooks = fs
+            .readdirSync(hooksDir)
+            .filter((f) => !f.endsWith(".sample"));
+        expect(hooks).not.toHaveLength(0);
+
+        expect(
+            fs.readFileSync(hookFile(tempDir, "commit-msg"), "utf8"),
+        ).toMatchSnapshot("commit-msg");
+
+        const preCommitContent = fs
+            .readFileSync(hookFile(tempDir, "pre-commit"), "utf8")
+            .replaceAll(tempDir, "<tempDir>");
+        expect(preCommitContent).toMatchSnapshot("pre-commit");
+    });
+
+    it("should install git hooks with postinstall script (Deprecated)", () => {
+        expect.assertions(1);
+
+        run(`npm install "${tarball}"`);
+
+        expect(fs.existsSync(hookFile(tempDir, "commit-msg"))).toBe(true);
+    });
+});

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -1,0 +1,29 @@
+import { defineConfig } from "vitest/config";
+
+const defaultExclude = ["**/node_modules/**"];
+
+const unitTestConfig = defineConfig({
+    test: {
+        exclude: [...defaultExclude, "**/*.integration.spec.ts"],
+    },
+});
+
+const integrationTestConfig = defineConfig({
+    test: {
+        globalSetup: ["./vitest.global.js"],
+        include: ["**/*.integration.spec.ts"],
+    },
+});
+
+export default defineConfig(({ mode }) => {
+    const { test } =
+        mode === "integration" ? integrationTestConfig : unitTestConfig;
+    return {
+        test,
+        server: {
+            watch: {
+                ignored: [...defaultExclude],
+            },
+        },
+    };
+});

--- a/vitest.global.js
+++ b/vitest.global.js
@@ -1,0 +1,11 @@
+/* eslint-disable sonarjs/no-os-command-from-path -- Static command */
+import { execSync } from "node:child_process";
+
+const rootDir = import.meta.dirname;
+
+export async function setup() {
+    // eslint-disable-next-line camelcase -- npm setting
+    const env = { ...process.env, npm_config_ignore_scripts: undefined };
+    execSync("npm run build", { cwd: rootDir, stdio: "inherit", env });
+    execSync("npm pack", { cwd: rootDir, stdio: "inherit", env });
+}


### PR DESCRIPTION
Integrations-test som initalt gör:

1. Paketerar tarball av vårt lib
2. Skapar upp ett git-repo i en temp-katalog
3. Skapar upp ett dummy npm-paket
4. Installerar tarball

Med denna setup kan vi sedan testa så att hooks appliceras korrekt.

Se detta mer som en grund för att kunna uttöka med fler tester.