### PR TITLE
feat: remove postinstall hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,11 @@ This package also provides the following git hooks:
 
 To validate commit messages as commits are created, you also need to set up the Git hooks.
 
-### Running setup manually (Recommended)
+```bash
+$ npm pkg set scripts.prepare="commitlint-config"
+```
 
-If you install with `--ignore-scripts`, the postinstall script will not run automatically.
-You can trigger the setup manually by calling the `commitlint-config` command, for example from your own `prepare` script:
+or manually edit your `package.json`
 
 ```json
 {
@@ -67,10 +68,6 @@ You can trigger the setup manually by calling the `commitlint-config` command, f
     }
 }
 ```
-
-### Postinstall script (Deprecated, will be removed in future releases)
-
-Hooks will automatically be installed if you omit `--no-script` when installing an application with this package. However, this is not a recommended approach and this alternative will be removed.
 
 ## Before installing this plugin
 

--- a/package.json
+++ b/package.json
@@ -37,22 +37,20 @@
     "prebuild": "rimraf dist",
     "build": "tsc && node build.js ",
     "postbuild": "cp -R node_modules/@commitlint/config-validator/lib/commitlint.schema.json dist/",
-    "prepack": "run-s pkg:mangle",
-    "postpack": "run-s pkg:restore",
-    "prepublishOnly": "run-s pkg:mangle",
     "eslint": "eslint .",
     "eslint:fix": "eslint --fix .",
-    "pkg:mangle": "run-s pkg:mangle:*",
-    "pkg:mangle:pack": "release-prepack package.json --bundle --retain-scripts",
-    "pkg:mangle:add": "npm pkg set scripts.postinstall=\"node bin/install.js\"",
+    "prepack": "run-s pkg:mangle",
+    "postpack": "run-s pkg:restore",
+    "pkg:mangle": "release-prepack package.json --bundle --retain-scripts",
     "pkg:restore": "release-postpack package.json",
     "prepare": "simple-git-hooks src/hooks.ts && git config commit.template gitmessage",
+    "prepublishOnly": "run-s pkg:mangle",
     "prettier:check": "prettier . --check",
     "prettier:write": "prettier . --write",
     "pretest": "run-s eslint prettier:check",
     "test": "vitest run && vitest run --mode integration",
-    "test:unit": "vitest run",
-    "test:integration": "vitest --mode integration"
+    "test:integration": "vitest --mode integration",
+    "test:unit": "vitest run"
   },
   "commitlint": {
     "extends": [

--- a/src/install.integration.spec.ts
+++ b/src/install.integration.spec.ts
@@ -47,7 +47,6 @@ describe("install (integration)", () => {
         await mkdir(tempDir);
 
         env["CI"] = "false";
-        env["npm_config_ignore_scripts"] = undefined; // Could be removed once postinstall script is removed
 
         run("git init");
         run("npm init -y");
@@ -87,34 +86,12 @@ describe("install (integration)", () => {
 
         env["CI"] = "true";
 
-        run(`npm install "${tarball}" --ignore-scripts`);
+        run(`npm install "${tarball}"`);
         const { stderr } = run("npm exec commitlint-config");
 
         expect(stderr).toBe("");
         expect(fs.existsSync(hookFile(tempDir, "commit-msg"))).toBe(false);
         expect(fs.existsSync(hookFile(tempDir, "pre-commit"))).toBe(false);
-    });
-
-    it("should install git hooks with postinstall script (Deprecated)", () => {
-        expect.assertions(1);
-
-        run(`npm install "${tarball}"`);
-
-        expect(fs.existsSync(hookFile(tempDir, "commit-msg"))).toBe(true);
-    });
-
-    it("should warn and skip adding hooks when not in a git repository", () => {
-        expect.assertions(2);
-
-        // Simulate a non-git repository
-        fs.rmSync(path.join(tempDir, ".git"), { recursive: true, force: true });
-
-        const { stdout, stderr } = run(
-            `npm install --foreground-scripts "${tarball}"`,
-        );
-
-        expect(stdout + stderr).toContain("Failed to locate git directory");
-        expect(fs.existsSync(path.join(tempDir, ".git", "hooks"))).toBe(false);
     });
 
     it("should exit with error when not in a git repository and run via commitlint-config", () => {
@@ -123,7 +100,7 @@ describe("install (integration)", () => {
         // Simulate a non-git repository
         fs.rmSync(path.join(tempDir, ".git"), { recursive: true, force: true });
 
-        run(`npm install "${tarball}" --ignore-scripts`);
+        run(`npm install "${tarball}"`);
         const result = run("npm exec commitlint-config");
 
         expect(result.stderr).toContain("Failed to locate git directory");

--- a/vitest.global.js
+++ b/vitest.global.js
@@ -4,8 +4,6 @@ import { execSync } from "node:child_process";
 const rootDir = import.meta.dirname;
 
 export async function setup() {
-    // eslint-disable-next-line camelcase -- npm setting
-    const env = { ...process.env, npm_config_ignore_scripts: undefined };
-    execSync("npm run build", { cwd: rootDir, stdio: "inherit", env });
-    execSync("npm pack", { cwd: rootDir, stdio: "inherit", env });
+    execSync("npm run build", { cwd: rootDir, stdio: "inherit" });
+    execSync("npm pack", { cwd: rootDir, stdio: "inherit" });
 }


### PR DESCRIPTION
BREAKING CHANGE: The postinstall hook has been removed, and the package no longer automatically installs git hooks. Users must now manually add `commitlint-config` into their prepare section in package.json

```bash
$ npm pkg set scripts.prepare="commitlint-config"
```

Read more about this change in the README.md file.

Changes is due to updates in upcoming version of npm 12 which changes the behavior of postinstall scripts. More info regarding NPM 12 changes can be found here:
* https://github.blog/changelog/2026-06-09-upcoming-breaking-changes-for-npm-v12/