### PR TITLE
refactor: remove traces of Jest

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,10 +61,6 @@
   "release": {
     "extends": "@forsakringskassan/semantic-release-config"
   },
-  "jest": {
-    "collectCoverage": false,
-    "preset": "@forsakringskassan/jest-config/esm"
-  },
   "dependencies": {
     "@commitlint/cli": "21.0.2",
     "@commitlint/config-conventional": "21.0.2",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,8 +1,6 @@
 {
     "extends": ["@tsconfig/node22", "@tsconfig/strictest"],
     "compilerOptions": {
-        /* ts-jest hardcodes moduleResolution node10 which is deprecated */
-        "ignoreDeprecations": "6.0",
         "rootDir": "./src/",
         "outDir": "./dist/",
         "noEmit": true,


### PR DESCRIPTION
Jest has been replaced by Vitest in earlier Pull Requests.